### PR TITLE
Add new secondary capture functionality 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -51,5 +51,5 @@ dependencies {
     implementation "com.squareup.retrofit2:retrofit:$retrofit_version"
     implementation "com.squareup.retrofit2:converter-gson:$retrofit_gson_version"
     implementation "com.squareup.okhttp3:logging-interceptor:$okhttp_interceptor_version"
-    implementation 'com.github.dimagi:rd-toolkit:0.6.0'
+    implementation 'com.github.dimagi:rd-toolkit:0.9.0'
 }

--- a/app/src/main/java/com/betterise/maladiecorona/QuestionActivity.kt
+++ b/app/src/main/java/com/betterise/maladiecorona/QuestionActivity.kt
@@ -574,6 +574,7 @@ class QuestionActivity : AppCompatActivity(), View.OnClickListener, GeolocManage
                 .setFlavorTwo(CW_SESSION_ID)
                 .setCloudworksBackend(CLOUDWORKS_DSN)
                 .requestTestProfile(COVID_TEST_PROFILE)
+                .setSecondaryCaptureRequirements("capture_windowed")
                 .build();
 
             startActivityForResult(intent, RDTOOLKIT_ACTIVITY_REQUEST_CODE)


### PR DESCRIPTION
Updates to the latest toolkit version builder, and sets a "Secondary Capture" requirement to ensure that at least one picture is taken with the normal (non-scan card) capture process. When the new classifier is enabled, this will ensure that if a scan card picture is taken, the app also requests the user to take a second picture with just the normal reticle. 